### PR TITLE
Fix message attribution in terminal chat interface

### DIFF
--- a/app/components/chat/chat-interface.tsx
+++ b/app/components/chat/chat-interface.tsx
@@ -232,7 +232,9 @@ export function ChatInterface({ isOpen, setIsOpen }: ChatInterfaceProps) {
         onMessage: (message) => {
           console.log('Agent message:', message)
           const prefix = message.source === 'user' ? 'prateek@ai:~$' : '[AI]'
-          setVoiceTranscript((prev) => [...prev, `${prefix} ${message.message}`])
+          const text = typeof message.message === 'string' ? message.message : ''
+          if (!text) return
+          setVoiceTranscript((prev) => [...prev, `${prefix} ${text}`])
         },
         onError: (error: unknown) => {
           console.error('Voice agent error:', error)

--- a/app/components/chat/chat-interface.tsx
+++ b/app/components/chat/chat-interface.tsx
@@ -231,7 +231,8 @@ export function ChatInterface({ isOpen, setIsOpen }: ChatInterfaceProps) {
         },
         onMessage: (message) => {
           console.log('Agent message:', message)
-          setVoiceTranscript((prev) => [...prev, `AI: ${message.message}`])
+          const prefix = message.source === 'user' ? 'prateek@ai:~$' : '[AI]'
+          setVoiceTranscript((prev) => [...prev, `${prefix} ${message.message}`])
         },
         onError: (error: unknown) => {
           console.error('Voice agent error:', error)

--- a/app/components/voice/voice-mode.tsx
+++ b/app/components/voice/voice-mode.tsx
@@ -53,7 +53,9 @@ export function VoiceMode({ isOpen, setIsOpen }: VoiceModeProps) {
         onMessage: (message) => {
           console.log('Agent message:', message)
           const prefix = message.source === 'user' ? 'USER:' : 'AI:'
-          setTranscript((prev) => [...prev, `${prefix} ${message.message}`])
+          const text = typeof message.message === 'string' ? message.message : ''
+          if (!text) return
+          setTranscript((prev) => [...prev, `${prefix} ${text}`])
         },
         onError: (error: unknown) => {
           console.error('Voice agent error:', error)

--- a/app/components/voice/voice-mode.tsx
+++ b/app/components/voice/voice-mode.tsx
@@ -52,7 +52,8 @@ export function VoiceMode({ isOpen, setIsOpen }: VoiceModeProps) {
         },
         onMessage: (message) => {
           console.log('Agent message:', message)
-          setTranscript((prev) => [...prev, `AI: ${message.message}`])
+          const prefix = message.source === 'user' ? 'USER:' : 'AI:'
+          setTranscript((prev) => [...prev, `${prefix} ${message.message}`])
         },
         onError: (error: unknown) => {
           console.error('Voice agent error:', error)


### PR DESCRIPTION
Both AI and user messages were incorrectly being attributed as "AI" in voice mode. Updated onMessage callbacks to check message.source property and display appropriate prefixes:
- User messages: "prateek@ai:~$" (chat-interface) or "USER:" (voice-mode)
- AI messages: "[AI]" (chat-interface) or "AI:" (voice-mode)

This ensures proper attribution of messages in both text and voice modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly attribute user and agent messages in chat and voice by checking message.source and applying the right prefix, and skip empty/non-string content to avoid undefined entries. Fixes the voice mode bug where all messages were labeled as AI.

- **Bug Fixes**
  - Chat: user → "prateek@ai:~$", agent → "[AI]"
  - Voice: user → "USER:", agent → "AI:"

<sup>Written for commit bbceb7179ef32338500da3d346c619c9ae21b58e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

